### PR TITLE
Prefer stable kdl crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "kdl"
-version = "5.0.0-alpha.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11eecaf214881ac67e858089a815fa8cad941abcf21113970a6c5bc6e6e557c8"
+checksum = "062c875482ccb676fd40c804a40e3824d4464c18c364547456d1c8e8e951ae47"
 dependencies = [
  "miette",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.89"
 dprint-core = { version = "0.67.1", features = ["wasm"] }
-kdl = "5.0.0-alpha.1"
+kdl = "4.6.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 


### PR DESCRIPTION
Apply same changes as GH-10 again to avoid alpha
channel of KDL crate such as GH-39

Closes GH-39
